### PR TITLE
feat(query): query module with CRUD, pagination, and notes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idurar-erp-crm",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idurar-erp-crm",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Fair-code License",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.509.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -10,6 +10,7 @@ const coreApiRouter = require('./routes/coreRoutes/coreApi');
 const coreDownloadRouter = require('./routes/coreRoutes/coreDownloadRouter');
 const corePublicRouter = require('./routes/coreRoutes/corePublicRouter');
 const adminAuth = require('./controllers/coreControllers/adminAuth');
+const queryRouter = require('./routes/appRoutes/queryRouter');
 
 const errorHandlers = require('./handlers/errorHandlers');
 const erpApiRouter = require('./routes/appRoutes/appApi');
@@ -42,6 +43,8 @@ app.use('/api', adminAuth.isValidAuthToken, erpApiRouter);
 app.use('/download', coreDownloadRouter);
 app.use('/public', corePublicRouter);
 
+//add query router
+app.use('/api', queryRouter);
 // If that above routes didnt work, we 404 them and forward to error handler
 app.use(errorHandlers.notFound);
 

--- a/backend/src/controllers/queriesControllers/addNote.js
+++ b/backend/src/controllers/queriesControllers/addNote.js
@@ -1,0 +1,39 @@
+const mongoose = require('mongoose');
+
+const Model = mongoose.model('Queries');
+
+const { noteSchema } = require('./schemaValidate');
+
+const addNote = async (req, res) => {
+  const { error, value } = noteSchema.validate(req.body, { stripUnknown: true });
+  if (error) {
+    const { details } = error;
+    return res.status(400).json({
+      success: false,
+      result: null,
+      message: details[0]?.message,
+    });
+  }
+
+  const query = await Model.findById(req.params.id);
+  if (!query) {
+    return res.status(404).json({
+      success: false,
+      result: null,
+      message: 'Query not found',
+    });
+  }
+
+  query.notes.push(value);
+  await query.save();
+
+  const result = query.notes;
+
+  return res.status(201).json({
+    success: true,
+    result,
+    message: 'Notes added successfully',
+  });
+};
+
+module.exports = addNote;

--- a/backend/src/controllers/queriesControllers/create.js
+++ b/backend/src/controllers/queriesControllers/create.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose');
+
+const Model = mongoose.model('Queries');
+
+const { createSchema } = require('./schemaValidate');
+
+const create = async (req, res) => {
+  const { error, value } = createSchema.validate(req.body, {
+    stripUnknown: true,
+  });
+
+  if (error) {
+    const { details } = error;
+    return res.status(400).json({
+      success: false,
+      result: null,
+      message: details[0]?.message,
+    });
+  }
+
+  const result = await new Model(value).save();
+
+  return res.status(201).json({
+    success: true,
+    result: result,
+    message: 'Query created successfully',
+  });
+};
+
+module.exports = create;

--- a/backend/src/controllers/queriesControllers/deleteNote.js
+++ b/backend/src/controllers/queriesControllers/deleteNote.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+
+const Model = mongoose.model('Queries');
+
+const deleteNote = async (req, res) => {
+  const { id, noteId } = req.params;
+
+  const query = await Model.findById(id);
+  if (!query) {
+    return res.status(404).json({
+      success: false,
+      result: null,
+      message: 'Query not found',
+    });
+  }
+
+  const noteInitialLength = query.notes.length;
+  query.notes = query.notes.filter((note) => note._id.toString() !== noteId);
+  if (noteInitialLength === query.notes.length) {
+    return res.status(404).json({
+      success: false,
+      result: null,
+      message: 'Note not found',
+    });
+  }
+
+  await query.save();
+
+  return res
+    .status(200)
+    .json({ success: true, result: query.notes, message: 'Note deleted successfully' });
+};
+
+module.exports = deleteNote;

--- a/backend/src/controllers/queriesControllers/index.js
+++ b/backend/src/controllers/queriesControllers/index.js
@@ -1,0 +1,25 @@
+// const createCRUDController = require('@/controllers/middlewaresControllers/createCRUDController');
+// const methods = createCRUDController('Queries');
+
+const create = require('./create');
+const paginatedList = require('./paginatedList');
+const read = require('./read');
+const update = require('./update');
+const addNote = require('./addNote');
+const deleteNote = require('./deleteNote');
+
+// methods.create = create;
+// methods.list = paginatedList;
+// methods.read = read;
+// methods.update = update;
+
+const queryMethods = {
+  read,
+  create,
+  update,
+  paginatedList,
+  addNote,
+  deleteNote,
+};
+
+module.exports = queryMethods;

--- a/backend/src/controllers/queriesControllers/paginatedList.js
+++ b/backend/src/controllers/queriesControllers/paginatedList.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+
+const Model = mongoose.model('Queries');
+
+const paginatedList = async (req, res) => {
+  const page = parseInt(req.query.page) || 1;
+  const limit = parseInt(req.query.limit) || 10;
+  const filter = req.query.filter || 'All';
+  const skip = page * limit - limit;
+  const query = {};
+
+  if (filter && filter !== 'All') {
+    query.status = filter;
+  }
+
+  const resultsPromise = Model.find(query).skip(skip).limit(limit).exec();
+  const countPromise = Model.countDocuments(query);
+
+  const [result, count] = await Promise.all([resultsPromise, countPromise]);
+
+  const pages = Math.ceil(count / limit);
+
+  const pagination = { page, pages, count };
+
+  return res.status(200).json({
+    success: true,
+    result,
+    pagination,
+    message: count > 0 ? 'Successfully found all documents' : 'Collection is Empty',
+  });
+};
+
+module.exports = paginatedList;

--- a/backend/src/controllers/queriesControllers/read.js
+++ b/backend/src/controllers/queriesControllers/read.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const Model = mongoose.model('Queries');
+
+const read = async (req, res) => {
+  const result = await Model.findOne({
+    _id: req.params.id,
+  }).exec();
+  return res.status(200).json({
+    success: true,
+    result,
+    message: result ? 'Document found.' : 'No document found.',
+  });
+};
+
+module.exports = read;

--- a/backend/src/controllers/queriesControllers/schemaValidate.js
+++ b/backend/src/controllers/queriesControllers/schemaValidate.js
@@ -1,0 +1,18 @@
+const Joi = require('joi');
+
+const createSchema = Joi.object({
+  customerName: Joi.string().required(),
+  description: Joi.string().required(),
+  status: Joi.string().valid('Open', 'Closed', 'InProgress').default('Open'),
+  notes: Joi.array().items(Joi.object({ content: Joi.string().required() })),
+  resolution: Joi.string().max(100).allow(''),
+});
+
+const updateSchema = Joi.object({
+  status: Joi.string().valid('Open', 'Closed', 'InProgress').default('Open'),
+  resolution: Joi.string().max(100).allow(''),
+});
+
+const noteSchema = Joi.object({ content: Joi.string().required() });
+
+module.exports = { createSchema, updateSchema, noteSchema };

--- a/backend/src/controllers/queriesControllers/update.js
+++ b/backend/src/controllers/queriesControllers/update.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose');
+
+const Model = mongoose.model('Queries');
+
+const { updateSchema } = require('./schemaValidate');
+
+const update = async (req, res) => {
+  const { error, value } = updateSchema.validate(req.body, { stripUnknown: true });
+
+  if (error) {
+    const { details } = error;
+    return res.status(400).json({
+      success: false,
+      result: null,
+      message: details[0]?.message,
+    });
+  }
+
+  const result = await Model.findOneAndUpdate({ _id: req.params.id }, value, {
+    new: true,
+  }).exec();
+
+  return res.status(200).json({
+    success: true,
+    result,
+    message: 'Document updated',
+  });
+};
+
+module.exports = update;

--- a/backend/src/models/appModels/Queries.js
+++ b/backend/src/models/appModels/Queries.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const noteSchema = new mongoose.Schema({
+  content: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const querySchema = new mongoose.Schema({
+  customerName: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    required: true,
+  },
+  status: { type: String, enum: ['Open', 'Closed', 'InProgress'], default: 'open' },
+  notes: [noteSchema],
+  resolution: { type: String, maxlength: 100 },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('Queries', querySchema);

--- a/backend/src/routes/appRoutes/queryRouter.js
+++ b/backend/src/routes/appRoutes/queryRouter.js
@@ -1,0 +1,20 @@
+const express = require('express');
+
+const { catchErrors } = require('@/handlers/errorHandlers');
+
+const router = express.Router();
+
+const queryController = require('@/controllers/queriesControllers');
+
+//______________Query Management______________________
+router.get('/queries/:id', catchErrors(queryController.read));
+router.get('/queries', catchErrors(queryController.paginatedList));
+
+router.post('/queries', catchErrors(queryController.create));
+router.post('/queries/:id/notes', catchErrors(queryController.addNote));
+
+router.put('/queries/:id', catchErrors(queryController.update));
+
+router.delete('/queries/:id/notes/:noteId', catchErrors(queryController.deleteNote));
+
+module.exports = router;

--- a/frontend/src/apps/Navigation/NavigationContainer.jsx
+++ b/frontend/src/apps/Navigation/NavigationContainer.jsx
@@ -26,6 +26,7 @@ import {
   FilterOutlined,
   WalletOutlined,
   ReconciliationOutlined,
+  QuestionCircleOutlined,
 } from '@ant-design/icons';
 
 const { Sider } = Layout;
@@ -69,6 +70,11 @@ function Sidebar({ collapsible, isMobile = false }) {
       key: 'quote',
       icon: <FileSyncOutlined />,
       label: <Link to={'/quote'}>{translate('quote')}</Link>,
+    },
+    {
+      key: 'queries',
+      label: <Link to={'/queries'}>{translate('queries')}</Link>,
+      icon: <QuestionCircleOutlined />,
     },
     {
       key: 'payment',

--- a/frontend/src/modules/QueriesModule/Forms/QueriesForm.jsx
+++ b/frontend/src/modules/QueriesModule/Forms/QueriesForm.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { Row, Col, Form, Input, Select, Divider, Button } from 'antd';
+import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import AutoCompleteAsync from '@/components/AutoCompleteAsync';
+import QueryTable from '../QueriesTableModule/QueryTable';
+
+const QueriesForm = React.memo(({ mode = 'create', ...props }) => {
+  const isUpdate = mode === 'update' ? true : false;
+
+  return (
+    <>
+      <Form.Item name="_id" style={{ display: 'none' }}>
+        <Input type="hidden" />
+      </Form.Item>
+      <Form.Item
+        name="customerName"
+        label="Customer Name"
+        rules={[{ required: true, message: 'Please select a customer' }]}
+        style={{ marginBottom: 20 }}
+      >
+        {mode === 'create' ? (
+          <AutoCompleteAsync
+            entity="client"
+            displayLabels={['name']}
+            searchFields="name"
+            redirectLabel="Add New Client"
+            withRedirect
+            outputValue="name"
+            urlToRedirect="/customer"
+          />
+        ) : (
+          <Input readOnly={isUpdate} />
+        )}
+      </Form.Item>
+      <Form.Item
+        name="description"
+        label="Description"
+        rules={[{ required: true, message: 'Please enter a description' }]}
+        style={{ marginBottom: 20 }}
+      >
+        <Input placeholder="Enter query description" readOnly={isUpdate} />
+      </Form.Item>
+      <Form.Item
+        name="status"
+        label="Status"
+        rules={[{ required: true, message: 'Please select a status' }]}
+        initialValue="Open"
+        style={{ marginBottom: 20 }}
+      >
+        <Select
+          options={[
+            { value: 'Open', label: 'Open' },
+            { value: 'InProgress', label: 'In Progress' },
+            { value: 'Closed', label: 'Closed' },
+          ]}
+          placeholder="Select status"
+        />
+      </Form.Item>
+      <Form.Item name="resolution" label="Resolution" style={{ marginBottom: 0 }}>
+        <Input.TextArea
+          placeholder="Enter resolution details (optional)"
+          autoSize={{ minRows: 3, maxRows: 6 }}
+          maxLength={100}
+        />
+      </Form.Item>
+
+      {!isUpdate ? (
+        <Form.List name="notes">
+          {(fields, { add, remove }) => (
+            <>
+              <Divider style={{ fontWeight: 'bold' }}>Notes</Divider>
+              {fields.map(({ key, name, ...restField }) => (
+                <Row key={key} gutter={8} align="middle" style={{ marginBottom: 8 }}>
+                  <Col flex="auto">
+                    <Form.Item
+                      {...restField}
+                      name={[name, 'content']}
+                      rules={[{ required: true, message: 'Please enter a note' }]}
+                      style={{ marginBottom: 0 }}
+                    >
+                      <Input placeholder="Enter note" />
+                    </Form.Item>
+                  </Col>
+                  <Col>
+                    <Button icon={<DeleteOutlined />} onClick={() => remove(name)} danger />
+                  </Col>
+                </Row>
+              ))}
+              <Form.Item>
+                <Button type="dashed" onClick={() => add()} block icon={<PlusOutlined />}>
+                  Add Note
+                </Button>
+              </Form.Item>
+            </>
+          )}
+        </Form.List>
+      ) : (
+        <>
+          <Divider dashed style={{ fontWeight: 'bold' }}>
+            Notes
+          </Divider>
+          <Row gutter={8} style={{ marginBottom: 20 }}>
+            <Col flex="auto">
+              <Form.Item name="note" style={{ marginBottom: 0 }}>
+                <Input placeholder="Add a note" />
+              </Form.Item>
+            </Col>
+            <Col>
+              <Button
+                type="primary"
+                onClick={() => props.handleNote('add', null)}
+                icon={<PlusOutlined />}
+              >
+                Add
+              </Button>
+            </Col>
+          </Row>
+          <QueryTable data={props.notes} columns={props.columns} />
+        </>
+      )}
+    </>
+  );
+});
+export default QueriesForm;

--- a/frontend/src/modules/QueriesModule/QueriesPageWrapper/QueriesPageWrapper.jsx
+++ b/frontend/src/modules/QueriesModule/QueriesPageWrapper/QueriesPageWrapper.jsx
@@ -1,0 +1,68 @@
+import React, { useCallback, useMemo } from 'react';
+import { PageHeader } from '@ant-design/pro-layout';
+import { Button } from 'antd';
+import {
+  ArrowLeftOutlined,
+  CloseCircleOutlined,
+  PlusOutlined,
+  EditOutlined,
+} from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+import { ErpLayout } from '@/layout';
+import PageLoader from '@/components/PageLoader';
+
+const QueryPageWrapper = ({
+  title,
+  onSubmit,
+  children,
+  isEdit = false,
+  isRead = false,
+  isLoading = false,
+}) => {
+  const navigate = useNavigate();
+
+  const handleBack = useCallback(() => {
+    navigate('/queries');
+  }, [navigate]);
+
+  const buttonLabel = isEdit ? 'Update' : isRead ? 'Edit' : 'Save';
+
+  const extraButtons = useMemo(
+    () => [
+      <Button key="cancel" onClick={handleBack} icon={<CloseCircleOutlined />}>
+        Cancel
+      </Button>,
+      <Button
+        key="submit"
+        onClick={onSubmit}
+        icon={!isRead ? <PlusOutlined /> : <EditOutlined />}
+        type="primary"
+      >
+        {buttonLabel}
+      </Button>,
+    ],
+    [handleBack, onSubmit, isEdit]
+  );
+  if (isLoading) {
+    return (
+      <ErpLayout>
+        <PageLoader />
+      </ErpLayout>
+    );
+  }
+  return (
+    <ErpLayout>
+      <PageHeader
+        onBack={handleBack}
+        backIcon={<ArrowLeftOutlined />}
+        title={title}
+        ghost={false}
+        extra={extraButtons}
+        style={{ padding: '20px 0px' }}
+      />
+      {children}
+    </ErpLayout>
+  );
+};
+
+export default QueryPageWrapper;

--- a/frontend/src/modules/QueriesModule/QueriesTableModule/QueryTable.jsx
+++ b/frontend/src/modules/QueriesModule/QueriesTableModule/QueryTable.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Table } from 'antd';
+const QueryTable = React.memo(({ data, loading, pagination, onChange, columns }) => {
+  return (
+    <Table
+      columns={columns}
+      dataSource={data}
+      loading={loading}
+      pagination={
+        pagination
+          ? {
+              current: pagination.current,
+              pageSize: 10,
+              total: pagination.total,
+              showTotal: (total) => `Total ${total} items`,
+            }
+          : false
+      }
+      onChange={onChange && onChange}
+      rowKey="_id"
+    />
+  );
+});
+
+export default QueryTable;

--- a/frontend/src/pages/Queries/QueriesCreate.jsx
+++ b/frontend/src/pages/Queries/QueriesCreate.jsx
@@ -1,0 +1,39 @@
+import React, { useCallback } from 'react';
+import { Form, message } from 'antd';
+import axios from 'axios';
+import QueriesForm from '@/modules/QueriesModule/Forms/QueriesForm';
+import QueryPageWrapper from '@/modules/QueriesModule/QueriesPageWrapper/QueriesPageWrapper';
+import { useNavigate } from 'react-router-dom';
+
+const QueriesCreate = () => {
+  const [form] = Form.useForm();
+  const navigate = useNavigate();
+
+  const onSubmit = useCallback(
+    async (values) => {
+      try {
+        const response = await axios.post('/queries', values);
+        message.success(response?.data.message);
+        form.resetFields();
+        navigate('/queries');
+      } catch (err) {
+        console.error('error occured', err);
+      }
+    },
+    [form, navigate]
+  );
+
+  const handleSubmit = useCallback(() => {
+    form.submit();
+  }, []);
+
+  return (
+    <QueryPageWrapper title="Create" onSubmit={handleSubmit}>
+      <Form form={form} layout="vertical" onFinish={onSubmit}>
+        <QueriesForm />
+      </Form>
+    </QueryPageWrapper>
+  );
+};
+
+export default QueriesCreate;

--- a/frontend/src/pages/Queries/QueriesRead.jsx
+++ b/frontend/src/pages/Queries/QueriesRead.jsx
@@ -1,0 +1,87 @@
+import React, { useCallback, useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { message, Descriptions, Tag, List, Divider, Card, Typography } from 'antd';
+
+import axios from 'axios';
+
+import QueryPageWrapper from '@/modules/QueriesModule/QueriesPageWrapper/QueriesPageWrapper';
+
+const { Paragraph } = Typography;
+
+const statusColors = {
+  Open: 'blue',
+  InProgress: 'orange',
+  Closed: 'green',
+};
+
+const QueriesRead = () => {
+  const [queryData, setQueryData] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  const handleEdit = useCallback(() => {
+    navigate(`/queries/update/${id}`);
+  }, [navigate, id]);
+
+  useEffect(() => {
+    fetchQuery();
+  }, [id]);
+
+  const fetchQuery = async () => {
+    setIsLoading(true);
+    try {
+      const { data } = await axios.get(`/queries/${id}`);
+      setQueryData(data?.result);
+      setIsLoading(false);
+    } catch (err) {
+      setIsLoading(false);
+      message.error('Failed to fetch query');
+      console.error('Failed to fetch query', err);
+    }
+  };
+
+  return (
+    <QueryPageWrapper title={'Query Detail'} onSubmit={handleEdit} isLoading={isLoading} isRead>
+      <>
+        <Descriptions
+          column={1}
+          bordered
+          size="middle"
+          labelStyle={{ width: 160, fontWeight: 500 }}
+        >
+          <Descriptions.Item label="Customer Name">{queryData.customerName}</Descriptions.Item>
+          <Descriptions.Item label="Description">
+            <Paragraph>{queryData.description}</Paragraph>
+          </Descriptions.Item>
+          <Descriptions.Item label="Status">
+            <Tag color={statusColors[queryData.status] || 'default'}>{queryData.status}</Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label="Resolution">
+            <Paragraph>{queryData.resolution}</Paragraph>
+          </Descriptions.Item>
+          <Descriptions.Item label="Created At">
+            {new Date(queryData.createdAt).toLocaleDateString()}
+          </Descriptions.Item>
+        </Descriptions>
+        <Divider orientation="left" style={{ marginTop: 32 }}>
+          Notes
+        </Divider>
+        <List
+          dataSource={queryData.notes}
+          locale={{ emptyText: 'No notes available' }}
+          itemLayout="horizontal"
+          style={{ marginTop: 0 }}
+          renderItem={(note) => (
+            <List.Item style={{ padding: '4px 0', border: 'none' }}>
+              <span style={{ marginRight: 8, fontSize: 18, lineHeight: 1 }}>&bull;</span>
+              <Paragraph style={{ marginBottom: 0, flex: 1 }}>{note.content}</Paragraph>
+            </List.Item>
+          )}
+        />
+      </>
+    </QueryPageWrapper>
+  );
+};
+
+export default QueriesRead;

--- a/frontend/src/pages/Queries/QueriesUpdate.jsx
+++ b/frontend/src/pages/Queries/QueriesUpdate.jsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+
+import { Form, message, Popconfirm, Button } from 'antd';
+import { DeleteOutlined } from '@ant-design/icons';
+
+import axios from 'axios';
+
+import QueryPageWrapper from '@/modules/QueriesModule/QueriesPageWrapper/QueriesPageWrapper';
+import QueriesForm from '@/modules/QueriesModule/Forms/QueriesForm';
+
+const QueriesUpdate = () => {
+  const [form] = Form.useForm();
+  const { id } = useParams();
+  const [notes, setNotes] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetchQuery();
+  }, [id]);
+
+  const fetchQuery = async () => {
+    setIsLoading(true);
+    try {
+      const { data } = await axios.get(`/queries/${id}`);
+      setNotes(data?.result.notes);
+      form.setFieldsValue(data?.result);
+      setIsLoading(false);
+    } catch (err) {
+      setIsLoading(false);
+      message.error('Failed to fetch query');
+      console.error('Failed to fetch query', err);
+    }
+  };
+
+  const onSubmit = useCallback(
+    async (values) => {
+      try {
+        const response = await axios.put(`/queries/${values._id}`, values);
+        message.success(response?.data.message);
+        form.resetFields();
+        navigate('/queries');
+      } catch (err) {
+        console.error('error occured', err);
+        message.error('Failed to update query');
+      }
+    },
+    [form, navigate]
+  );
+
+  const handleSubmit = useCallback(() => {
+    form.submit();
+  }, []);
+
+  const handleNote = useCallback(async (action = 'add', noteId) => {
+    const queryId = form.getFieldValue('_id');
+    try {
+      let response;
+      if (action !== 'add') {
+        response = await axios.delete(`/queries/${queryId}/notes/${noteId}`);
+      } else {
+        const noteContent = form.getFieldValue('note');
+        if (!noteContent?.trim()) {
+          message.warning('Please enter a note');
+          return;
+        }
+        response = await axios.post(`/queries/${queryId}/notes`, {
+          content: noteContent,
+        });
+        form.setFieldsValue({ note: '' });
+      }
+      message.success(response.data?.message);
+      setNotes(response?.data?.result || []);
+    } catch (err) {
+      console.log('error in the handle removeNote fn', err);
+      message.error('Failed to update notes');
+    }
+  });
+
+  const columns = useMemo(
+    () => [
+      {
+        title: 'Note',
+        dataIndex: 'content',
+        key: 'content',
+        ellipsis: true,
+      },
+      {
+        title: 'Created Date',
+        dataIndex: 'createdAt',
+        key: 'createdAt',
+        width: 140,
+        render: (date) => new Date(date).toLocaleDateString(),
+      },
+      {
+        title: 'Action',
+        key: 'action',
+        width: 80,
+        render: (_, record) => (
+          <Popconfirm
+            title="Delete this note?"
+            onConfirm={() => handleNote('delete', record?._id)}
+            okText="Yes"
+            cancelText="No"
+          >
+            <Button danger size="small" icon={<DeleteOutlined />}></Button>
+          </Popconfirm>
+        ),
+      },
+    ],
+    [handleNote]
+  );
+  return (
+    <QueryPageWrapper title="Update" onSubmit={handleSubmit} isLoading={isLoading} isEdit>
+      <Form form={form} layout="vertical" onFinish={onSubmit}>
+        <QueriesForm mode="update" notes={notes} columns={columns} handleNote={handleNote} />
+      </Form>
+    </QueryPageWrapper>
+  );
+};
+
+export default QueriesUpdate;

--- a/frontend/src/pages/Queries/index.jsx
+++ b/frontend/src/pages/Queries/index.jsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import axios from 'axios';
+import { Card, Button, Flex, Select, Dropdown } from 'antd';
+import { PlusOutlined, EditOutlined, EllipsisOutlined, EyeOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+import QueryTable from '@/modules/QueriesModule/QueriesTableModule/QueryTable';
+
+const Queries = () => {
+  const [queries, setQueries] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState('All');
+  const [pagination, setPagination] = useState({ current: 1, total: 0 });
+  const navigate = useNavigate();
+  useEffect(() => {
+    fetchQueries();
+  }, [filter, pagination.current]);
+
+  const fetchQueries = async () => {
+    try {
+      setLoading(true);
+      const { data } = await axios.get(
+        `/queries?page=${pagination.current}&limit=${10}&filter=${filter}`
+      );
+      setQueries(data?.result);
+      setPagination({ current: data?.pagination.page, total: data?.pagination.count });
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleTableChange = useCallback((pagination) => {
+    setPagination((prev) => ({
+      ...prev,
+      current: pagination.current,
+    }));
+  });
+
+  const handleChange = useCallback((value) => {
+    setFilter(value);
+    setPagination((prev) => ({ ...prev, current: 1 }));
+  });
+
+  const handleAction = useCallback(
+    (action, id) => {
+      if (action == 'edit') {
+        navigate(`/queries/update/${id}`);
+      } else if (action == 'show') {
+        navigate(`/queries/read/${id}`);
+      }
+    },
+    [navigate]
+  );
+
+  const handleCreate = () => {
+    navigate(`/queries/create`);
+  };
+
+  const columns = useMemo(
+    () => [
+      {
+        title: 'Customer Name',
+        dataIndex: 'customerName',
+      },
+      {
+        title: 'Description',
+        dataIndex: 'description',
+      },
+      {
+        title: 'Creation Date',
+        dataIndex: 'createdAt',
+        render: (date) => new Date(date).toLocaleDateString(),
+      },
+      {
+        title: 'Status',
+        dataIndex: 'status',
+      },
+      {
+        title: 'Resolution',
+        dataIndex: 'resolution',
+        ellipsis: true,
+      },
+      {
+        title: '',
+        key: 'action',
+        fixed: 'right',
+        width: 80,
+        render: (_, record) => (
+          <Dropdown
+            menu={{
+              items: [
+                { label: 'Show', key: 'show', icon: <EyeOutlined /> },
+                {
+                  label: 'Edit',
+                  key: 'edit',
+                  icon: <EditOutlined />,
+                },
+              ],
+              onClick: ({ key }) => {
+                handleAction(key, record?._id);
+              },
+            }}
+          >
+            <EllipsisOutlined
+              style={{ cursor: 'pointer', fontSize: '24px' }}
+              onClick={(e) => e.preventDefault()}
+            />
+          </Dropdown>
+        ),
+      },
+    ],
+    [handleAction]
+  );
+  return (
+    <Card
+      title="Queries List"
+      extra={
+        <Flex gap={'small'} wrap>
+          <span style={{ alignSelf: 'center' }}>Filter by Status:</span>
+          <Select
+            value={filter}
+            style={{ width: 120 }}
+            onChange={handleChange}
+            options={[
+              { value: 'Open', label: 'Open' },
+              { value: 'InProgress', label: 'In Progress' },
+              { value: 'Closed', label: 'Closed' },
+              { value: 'All', label: 'All' },
+            ]}
+          />{' '}
+          <Button type="primary" onClick={handleCreate}>
+            <PlusOutlined />
+            Add Query
+          </Button>
+        </Flex>
+      }
+      className="whiteBox shadow layoutPadding"
+      style={{
+        margin: '30px auto',
+        width: '100%',
+        maxWidth: '1100px',
+        minHeight: '600px',
+      }}
+    >
+      <QueryTable
+        data={queries}
+        columns={columns}
+        loading={loading}
+        pagination={pagination}
+        onChange={handleTableChange}
+      />
+    </Card>
+  );
+};
+
+export default Queries;

--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -29,6 +29,12 @@ const Profile = lazy(() => import('@/pages/Profile'));
 
 const About = lazy(() => import('@/pages/About'));
 
+//adding the query module routes
+const Queries = lazy(() => import('@/pages/Queries'));
+const QueriesCreate = lazy(() => import('@/pages/Queries/QueriesCreate'));
+const QueriesUpdate = lazy(() => import('@/pages/Queries/QueriesUpdate'));
+const QueriesRead = lazy(() => import('@/pages/Queries/QueriesRead'));
+
 let routes = {
   expense: [],
   default: [
@@ -127,6 +133,10 @@ let routes = {
       path: '*',
       element: <NotFound />,
     },
+    { path: '/queries', element: <Queries /> },
+    { path: '/queries/create', element: <QueriesCreate /> },
+    { path: '/queries/update/:id', element: <QueriesUpdate /> },
+    { path: '/queries/read/:id', element: <QueriesRead /> },
   ],
 };
 


### PR DESCRIPTION
## Description

This PR introduces the Query Management module. It includes:

- CRUD APIs for queries
- Pagination support via
- Note field per query
- UI with listing, filtering, and query creation form

This module is standalone and does not include AI summary logic.

## Related Issues

N/A – Project requirement Phase 2

## Steps to Test

1. Run `npm run dev`
2. Visit `Queries` option on the frontend navbar
3. Use "Add Query" to submit a new query with notes
4. Pagination and filtering should work correctly

## Screenshots (if applicable)

- [x] UI: Query List Table
- [x] UI: Query Create Form
- [x] UI: Query Update Form
- [x]  UI:Query Read Form 
- [x] API: Postman success for GET, POST, DELETE
![ui_query_update_form](https://github.com/user-attachments/assets/98cd61aa-8d69-4fde-af1f-7c0305902497)
![ui_query_read_form](https://github.com/user-attachments/assets/1124402e-5005-4281-8b1d-32ee215bf921)
![ui_query_create_new_form](https://github.com/user-attachments/assets/57b46262-2b5d-4fb2-9c34-bb8722d304f3)
![ui_query_list](https://github.com/user-attachments/assets/2dd3526c-835f-4473-b5e8-7bfc018b0234)
![query_test](https://github.com/user-attachments/assets/b135c113-39ba-4c0d-b9a7-039780bf474e)

## docs
- [x] API: Postman test run summary
- [x] API: Postman collections
[pente_ai_query_test_cases.postman_collection.json](https://github.com/user-attachments/files/20889715/pente_ai_query_test_cases.postman_collection.json)
[pente_ai_query_test_cases.postman_test_run_summary.json](https://github.com/user-attachments/files/20889716/pente_ai_query_test_cases.postman_test_run_summary.json)

## Checklist

- [x] I have tested these changes
- [x] I have updated the relevant documentation
- [x] I have commented my code
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
