### PR TITLE
fix(invoice): add note field to invoice line items (UI + schema)

### DIFF
--- a/backend/src/controllers/appControllers/invoiceController/schemaValidate.js
+++ b/backend/src/controllers/appControllers/invoiceController/schemaValidate.js
@@ -17,6 +17,7 @@ const schema = Joi.object({
         quantity: Joi.number().required(),
         price: Joi.number().required(),
         total: Joi.number().required(),
+        note: Joi.string().required(),
       }).required()
     )
     .required(),

--- a/backend/src/models/appModels/Invoice.js
+++ b/backend/src/models/appModels/Invoice.js
@@ -91,6 +91,11 @@ const invoiceSchema = new mongoose.Schema({
         type: Number,
         required: true,
       },
+      //added note field
+      note: {
+        type: String,
+        required: true,
+      },
     },
   ],
   taxRate: {

--- a/backend/src/pdf/Invoice.pug
+++ b/backend/src/pdf/Invoice.pug
@@ -296,6 +296,7 @@ html
           thead
             tr.tableHeader
               th.service #{translate('item')}
+              th.service #{translate('Note')}
               th #{translate('Quantity')}
               th #{translate('PRICE')}
               th #{translate('TOTAL')}
@@ -304,6 +305,8 @@ html
               tr
                 td.service #{item.itemName}
                   span #{item.description}
+                   //- |note in pdf
+                td.service #{item.note} 
                 td.qty #{item.quantity}  
                 td.unit  #{moneyFormatter({amount:item.price})}
                 td.total #{moneyFormatter({amount:item.total})}

--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -5,10 +5,18 @@ import { DeleteOutlined } from '@ant-design/icons';
 import { useMoney, useDate } from '@/settings';
 import calculate from '@/utils/calculate';
 
-export default function ItemRow({ field, remove, current = null }) {
+const ITEM_CONFIG = {
+  invoice: { spans: { itemName: 3, description: 4, note: 5, quantity: 3, price: 4, total: 5 } },
+  default: { spans: { itemName: 5, description: 7, note: 0, quantity: 3, price: 4, total: 5 } },
+};
+
+export default function ItemRow({ field, remove, current = null, showNotes = false }) {
   const [totalState, setTotal] = useState(undefined);
   const [price, setPrice] = useState(0);
   const [quantity, setQuantity] = useState(0);
+
+  //dynmically creating span
+  const spanConfig = showNotes ? ITEM_CONFIG.invoice.spans : ITEM_CONFIG.default.spans;
 
   const money = useMoney();
   const updateQt = (value) => {
@@ -53,7 +61,7 @@ export default function ItemRow({ field, remove, current = null }) {
 
   return (
     <Row gutter={[12, 12]} style={{ position: 'relative' }}>
-      <Col className="gutter-row" span={5}>
+      <Col className="gutter-row" span={spanConfig.itemName}>
         <Form.Item
           name={[field.name, 'itemName']}
           rules={[
@@ -70,17 +78,36 @@ export default function ItemRow({ field, remove, current = null }) {
           <Input placeholder="Item Name" />
         </Form.Item>
       </Col>
-      <Col className="gutter-row" span={7}>
+      <Col className="gutter-row" span={spanConfig.description}>
         <Form.Item name={[field.name, 'description']}>
           <Input placeholder="description Name" />
         </Form.Item>
       </Col>
-      <Col className="gutter-row" span={3}>
+      {showNotes && (
+        <Col className="gutter-row" span={spanConfig.note}>
+          <Form.Item
+            name={[field.name, 'note']}
+            rules={[
+              {
+                required: true,
+                message: 'note is required',
+              },
+            ]}
+          >
+            <Input.TextArea
+              autoSize={{ minRows: 1, maxRows: 2 }}
+              style={{ resize: 'vertical' }}
+              placeholder="Add a note"
+            />
+          </Form.Item>
+        </Col>
+      )}
+      <Col className="gutter-row" span={spanConfig.quantity}>
         <Form.Item name={[field.name, 'quantity']} rules={[{ required: true }]}>
           <InputNumber style={{ width: '100%' }} min={0} onChange={updateQt} />
         </Form.Item>
       </Col>
-      <Col className="gutter-row" span={4}>
+      <Col className="gutter-row" span={spanConfig.price}>
         <Form.Item name={[field.name, 'price']} rules={[{ required: true }]}>
           <InputNumber
             className="moneyInput"
@@ -92,7 +119,7 @@ export default function ItemRow({ field, remove, current = null }) {
           />
         </Form.Item>
       </Col>
-      <Col className="gutter-row" span={5}>
+      <Col className="gutter-row" span={spanConfig.total}>
         <Form.Item name={[field.name, 'total']}>
           <Form.Item>
             <InputNumber

--- a/frontend/src/modules/ErpPanelModule/ReadItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/ReadItem.jsx
@@ -24,16 +24,26 @@ import { useMoney, useDate } from '@/settings';
 import useMail from '@/hooks/useMail';
 import { useNavigate } from 'react-router-dom';
 
-const Item = ({ item, currentErp }) => {
+const ITEM_CONFIG = {
+  invoice: { spans: { product: 6, itemName: 8, note: 6, quantity: 3, price: 4, total: 5 } },
+  default: { spans: { product: 6, itemName: 8, note: 0, quantity: 3, price: 4, total: 5 } },
+};
+
+const Item = ({ item, currentErp, showNotes = false }) => {
   const { moneyFormatter } = useMoney();
   return (
     <Row gutter={[12, 0]} key={item._id}>
-      <Col className="gutter-row" span={11}>
+      <Col className="gutter-row" span={6}>
         <p style={{ marginBottom: 5 }}>
           <strong>{item.itemName}</strong>
         </p>
         <p>{item.description}</p>
       </Col>
+      {showNotes && (
+        <Col className="gutter-row" span={6}>
+          <p>{item.note}</p>
+        </Col>
+      )}
       <Col className="gutter-row" span={4}>
         <p
           style={{
@@ -43,7 +53,8 @@ const Item = ({ item, currentErp }) => {
           {moneyFormatter({ amount: item.price, currency_code: currentErp.currency })}
         </p>
       </Col>
-      <Col className="gutter-row" span={4}>
+
+      <Col className="gutter-row" span={3}>
         <p
           style={{
             textAlign: 'right',
@@ -67,7 +78,7 @@ const Item = ({ item, currentErp }) => {
   );
 };
 
-export default function ReadItem({ config, selectedItem }) {
+export default function ReadItem({ config, selectedItem, showNotes = false }) {
   const translate = useLanguage();
   const { entity, ENTITY_NAME } = config;
   const dispatch = useDispatch();
@@ -98,6 +109,9 @@ export default function ReadItem({ config, selectedItem }) {
   const [itemslist, setItemsList] = useState([]);
   const [currentErp, setCurrentErp] = useState(selectedItem ?? resetErp);
   const [client, setClient] = useState({});
+
+  //dynamically assigning span
+  const spanConfig = showNotes ? ITEM_CONFIG.invoice.spans : ITEM_CONFIG.default.spans;
 
   useEffect(() => {
     if (currentResult) {
@@ -242,12 +256,19 @@ export default function ReadItem({ config, selectedItem }) {
       </Descriptions>
       <Divider />
       <Row gutter={[12, 0]}>
-        <Col className="gutter-row" span={11}>
+        <Col className="gutter-row" span={spanConfig.product}>
           <p>
             <strong>{translate('Product')}</strong>
           </p>
         </Col>
-        <Col className="gutter-row" span={4}>
+        {showNotes && (
+          <Col className="gutter-row" span={spanConfig.note}>
+            <p>
+              <strong>{translate('Note')}</strong>
+            </p>
+          </Col>
+        )}
+        <Col className="gutter-row" span={spanConfig.price}>
           <p
             style={{
               textAlign: 'right',
@@ -256,7 +277,7 @@ export default function ReadItem({ config, selectedItem }) {
             <strong>{translate('Price')}</strong>
           </p>
         </Col>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={spanConfig.quantity}>
           <p
             style={{
               textAlign: 'right',
@@ -265,7 +286,7 @@ export default function ReadItem({ config, selectedItem }) {
             <strong>{translate('Quantity')}</strong>
           </p>
         </Col>
-        <Col className="gutter-row" span={5}>
+        <Col className="gutter-row" span={spanConfig.total}>
           <p
             style={{
               textAlign: 'right',
@@ -277,7 +298,7 @@ export default function ReadItem({ config, selectedItem }) {
         <Divider />
       </Row>
       {itemslist.map((item) => (
-        <Item key={item._id} item={item} currentErp={currentErp}></Item>
+        <Item key={item._id} item={item} currentErp={currentErp} showNotes={showNotes}></Item>
       ))}
       <div
         style={{

--- a/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
@@ -92,9 +92,9 @@ export default function UpdateItem({ config, UpdateForm }) {
       if (fieldsValue.items) {
         let newList = [];
         fieldsValue.items.map((item) => {
-          const { quantity, price, itemName, description } = item;
+          const { quantity, price, itemName, description, note } = item;
           const total = item.quantity * item.price;
-          newList.push({ total, quantity, price, itemName, description });
+          newList.push({ total, quantity, price, itemName, description, note });
         });
         dataToUpdate.items = newList;
       }

--- a/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
+++ b/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
@@ -174,11 +174,14 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
       </Row>
       <Divider dashed />
       <Row gutter={[12, 12]} style={{ position: 'relative' }}>
-        <Col className="gutter-row" span={5}>
+        <Col className="gutter-row" span={3}>
           <p>{translate('Item')}</p>
         </Col>
-        <Col className="gutter-row" span={7}>
+        <Col className="gutter-row" span={4}>
           <p>{translate('Description')}</p>
+        </Col>
+        <Col className="gutter-row" span={5}>
+          <p>{translate('Note')}</p>
         </Col>
         <Col className="gutter-row" span={3}>
           <p>{translate('Quantity')}</p>{' '}
@@ -194,7 +197,13 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
         {(fields, { add, remove }) => (
           <>
             {fields.map((field) => (
-              <ItemRow key={field.key} remove={remove} field={field} current={current}></ItemRow>
+              <ItemRow
+                key={field.key}
+                remove={remove}
+                field={field}
+                current={current}
+                showNotes
+              ></ItemRow>
             ))}
             <Form.Item>
               <Button

--- a/frontend/src/modules/InvoiceModule/ReadInvoiceModule/index.jsx
+++ b/frontend/src/modules/InvoiceModule/ReadInvoiceModule/index.jsx
@@ -30,7 +30,7 @@ export default function ReadInvoiceModule({ config }) {
     return (
       <ErpLayout>
         {isSuccess ? (
-          <ReadItem config={config} selectedItem={currentResult} />
+          <ReadItem config={config} selectedItem={currentResult} showNotes />
         ) : (
           <NotFound entity={config.entity} />
         )}


### PR DESCRIPTION
## Description

This PR addresses a schema and UI bug by introducing a `note` field in each invoice line item. Includes:

- Schema updates in backend (Mongoose & validation)
- UI updates in invoice form and PDF
- Backward compatibility retained

## Related Issues

N/A – Bugfix Phase 3 (Bugfix 1)

## Steps to Test

1. Run backend & frontend
2. Create or edit an invoice → add notes to line items
3. Check if notes are saved and appear in:
   - UI
   - PDF export

## Screenshots (if applicable)

- [x] Invoice Form UI with new note field
- [x] Invoice PDF showing note value
[invoice_note_pdf.pdf](https://github.com/user-attachments/files/20890109/invoice_note_pdf.pdf)
![ui_invoice_update_form](https://github.com/user-attachments/assets/ec428d4b-a6f3-4ad9-b63e-26733295088f)
![ui_invoice_read_form](https://github.com/user-attachments/assets/f929a594-9709-4320-89d9-bcf38cc810df)
![ui_invoice_create_form](https://github.com/user-attachments/assets/7b31fbf4-38cf-4d0b-91a7-c253c01ccf2a)

## Checklist

- [x] I have tested these changes
- [x] I have updated the relevant documentation
- [x] I have commented my code
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
